### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ioredis": "^2.3.0",
     "kue": "^0.11.1",
     "lodash": "^4.15.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "delay": "^1.3.1",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const delay = require('delay');
 const JM = require('../../lib/jobManager');
 const config = require('../configWithSentinel');

--- a/test/unit/jobManager.test.js
+++ b/test/unit/jobManager.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('expect');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const delay = require('delay');
 const sinon = require('sinon');
 // const testQ = require('kue').createQueue();

--- a/test/unit/taskSeries.test.js
+++ b/test/unit/taskSeries.test.js
@@ -2,7 +2,7 @@
 
 const expect = require('expect');
 const sinon = require('sinon');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const JM = require('../../lib/jobManager');
 const Series = require('../../lib/taskSeries');
 const config = require('../configWithSentinel');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.